### PR TITLE
Take list of all options (as a function of model) in the dropdown config

### DIFF
--- a/examples/Example1.elm
+++ b/examples/Example1.elm
@@ -88,4 +88,11 @@ dropdownConfig =
         itemToElement selected highlighted item =
             text item
     in
-    Dropdown.basic (always options) .selectedOption DropdownMsg OptionPicked itemToPrompt itemToElement
+    Dropdown.basic
+        { allItems = always options
+        , selectedItem = .selectedOption
+        , dropdownMsg = DropdownMsg
+        , onSelectMsg = OptionPicked
+        , itemToPrompt = itemToPrompt
+        , itemToElement = itemToElement
+        }

--- a/examples/Example1.elm
+++ b/examples/Example1.elm
@@ -54,7 +54,7 @@ update msg model =
         DropdownMsg subMsg ->
             let
                 ( state, cmd ) =
-                    Dropdown.update dropdownConfig subMsg model model.dropdownState options
+                    Dropdown.update dropdownConfig subMsg model model.dropdownState
             in
             ( { model | dropdownState = state }, cmd )
 
@@ -74,7 +74,7 @@ subscriptions model =
 
 view : Model -> Html Msg
 view model =
-    Dropdown.view dropdownConfig model model.dropdownState options
+    Dropdown.view dropdownConfig model model.dropdownState
         |> el []
         |> layout []
 
@@ -88,4 +88,4 @@ dropdownConfig =
         itemToElement selected highlighted item =
             text item
     in
-    Dropdown.basic .selectedOption DropdownMsg OptionPicked itemToPrompt itemToElement
+    Dropdown.basic (always options) .selectedOption DropdownMsg OptionPicked itemToPrompt itemToElement

--- a/examples/Example1.elm
+++ b/examples/Example1.elm
@@ -16,9 +16,13 @@ main =
         }
 
 
+type alias Item =
+    String
+
+
 type alias Model =
-    { dropdownState : Dropdown.State
-    , selectedOption : Maybe String
+    { dropdownState : Dropdown.State Item
+    , selectedOption : Maybe Item
     }
 
 
@@ -31,7 +35,7 @@ init _ =
     )
 
 
-options : List String
+options : List Item
 options =
     [ "Option 1", "Option 2", "Option 3" ]
 
@@ -41,8 +45,8 @@ options =
 
 
 type Msg
-    = OptionPicked (Maybe String)
-    | DropdownMsg (Dropdown.Msg String)
+    = OptionPicked (Maybe Item)
+    | DropdownMsg (Dropdown.Msg Item)
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -79,7 +83,7 @@ view model =
         |> layout []
 
 
-dropdownConfig : Dropdown.Config String Msg Model
+dropdownConfig : Dropdown.Config Item Msg Model
 dropdownConfig =
     let
         itemToPrompt item =

--- a/examples/Example2.elm
+++ b/examples/Example2.elm
@@ -128,7 +128,15 @@ dropdownConfig =
                 , el [ Font.size 16 ] (text i)
                 ]
     in
-    Dropdown.filterable (always options) .selectedOption DropdownMsg OptionPicked itemToPrompt itemToElement identity
+    Dropdown.filterable
+        { allItems = always options
+        , selectedItem = .selectedOption
+        , dropdownMsg = DropdownMsg
+        , onSelectMsg = OptionPicked
+        , itemToPrompt = itemToPrompt
+        , itemToElement = itemToElement
+        , itemToText = identity
+        }
         |> Dropdown.withContainerAttributes containerAttrs
         |> Dropdown.withPromptElement (el [] (text "Select option"))
         |> Dropdown.withFilterPlaceholder "Type for option"

--- a/examples/Example2.elm
+++ b/examples/Example2.elm
@@ -57,7 +57,7 @@ update msg model =
         DropdownMsg subMsg ->
             let
                 ( state, cmd ) =
-                    Dropdown.update dropdownConfig subMsg model model.dropdownState options
+                    Dropdown.update dropdownConfig subMsg model model.dropdownState
             in
             ( { model | dropdownState = state }, cmd )
 
@@ -79,7 +79,7 @@ view : Model -> Html Msg
 view model =
     column [ padding 20, spacing 20 ]
         [ el [] <| text <| "Selected Option: " ++ (model.selectedOption |> Maybe.withDefault "Nothing")
-        , Dropdown.view dropdownConfig model model.dropdownState options
+        , Dropdown.view dropdownConfig model model.dropdownState
         ]
         |> layout []
 
@@ -128,7 +128,7 @@ dropdownConfig =
                 , el [ Font.size 16 ] (text i)
                 ]
     in
-    Dropdown.filterable .selectedOption DropdownMsg OptionPicked itemToPrompt itemToElement identity
+    Dropdown.filterable (always options) .selectedOption DropdownMsg OptionPicked itemToPrompt itemToElement identity
         |> Dropdown.withContainerAttributes containerAttrs
         |> Dropdown.withPromptElement (el [] (text "Select option"))
         |> Dropdown.withFilterPlaceholder "Type for option"

--- a/examples/Example2.elm
+++ b/examples/Example2.elm
@@ -19,9 +19,13 @@ main =
         }
 
 
+type alias Item =
+    String
+
+
 type alias Model =
-    { dropdownState : Dropdown.State
-    , selectedOption : Maybe String
+    { dropdownState : Dropdown.State Item
+    , selectedOption : Maybe Item
     }
 
 
@@ -34,7 +38,7 @@ init _ =
     )
 
 
-options : List String
+options : List Item
 options =
     [ "Option 1", "Option 2", "Option 3", "Option 4", "Option 5", "Option 6" ]
 
@@ -44,8 +48,8 @@ options =
 
 
 type Msg
-    = OptionPicked (Maybe String)
-    | DropdownMsg (Dropdown.Msg String)
+    = OptionPicked (Maybe Item)
+    | DropdownMsg (Dropdown.Msg Item)
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -84,7 +88,7 @@ view model =
         |> layout []
 
 
-dropdownConfig : Dropdown.Config String Msg Model
+dropdownConfig : Dropdown.Config Item Msg Model
 dropdownConfig =
     let
         containerAttrs =

--- a/examples/Example3.elm
+++ b/examples/Example3.elm
@@ -193,7 +193,15 @@ dropdownConfig allOptions selectedFromModel dropdownMsg itemPickedMsg =
                 ]
                 (text i)
     in
-    Dropdown.filterable allOptions selectedFromModel dropdownMsg itemPickedMsg itemToPrompt itemToElement identity
+    Dropdown.filterable
+        { allItems = allOptions
+        , selectedItem = selectedFromModel
+        , dropdownMsg = dropdownMsg
+        , onSelectMsg = itemPickedMsg
+        , itemToPrompt = itemToPrompt
+        , itemToElement = itemToElement
+        , itemToText = identity
+        }
         |> Dropdown.withContainerAttributes containerAttrs
         |> Dropdown.withSelectAttributes selectAttrs
         |> Dropdown.withListAttributes listAttrs

--- a/examples/Example3.elm
+++ b/examples/Example3.elm
@@ -20,8 +20,8 @@ main =
 
 
 type alias Model =
-    { countryDropdownState : Dropdown.State
-    , cityDropdownState : Dropdown.State
+    { countryDropdownState : Dropdown.State Country
+    , cityDropdownState : Dropdown.State City
     , country : Maybe Country
     , city : Maybe City
     }

--- a/examples/Example3.elm
+++ b/examples/Example3.elm
@@ -100,19 +100,14 @@ update msg model =
         CountryDropdownMsg subMsg ->
             let
                 ( state, cmd ) =
-                    Dropdown.update countryConfig subMsg model model.countryDropdownState countries
+                    Dropdown.update countryConfig subMsg model model.countryDropdownState
             in
             ( { model | countryDropdownState = state }, cmd )
 
         CityDropdownMsg subMsg ->
             let
-                cities =
-                    model.country
-                        |> Maybe.andThen (\c -> Dict.get c allCities)
-                        |> Maybe.withDefault []
-
                 ( state, cmd ) =
-                    Dropdown.update cityConfig subMsg model model.cityDropdownState cities
+                    Dropdown.update cityConfig subMsg model model.cityDropdownState
             in
             ( { model | cityDropdownState = state }, cmd )
 
@@ -132,15 +127,9 @@ subscriptions model =
 
 view : Model -> Html Msg
 view model =
-    let
-        cities =
-            model.country
-                |> Maybe.andThen (\c -> Dict.get c allCities)
-                |> Maybe.withDefault []
-    in
     row []
-        [ Dropdown.view countryConfig model model.countryDropdownState countries
-        , Dropdown.view cityConfig model model.cityDropdownState cities
+        [ Dropdown.view countryConfig model model.countryDropdownState
+        , Dropdown.view cityConfig model model.cityDropdownState
         ]
         |> el [ width fill, height fill, padding 20 ]
         |> layout []
@@ -148,16 +137,22 @@ view model =
 
 countryConfig : Dropdown.Config String Msg Model
 countryConfig =
-    dropdownConfig .country CountryDropdownMsg CountryPicked
+    dropdownConfig (always countries) .country CountryDropdownMsg CountryPicked
 
 
 cityConfig : Dropdown.Config String Msg Model
 cityConfig =
-    dropdownConfig .city CityDropdownMsg CityPicked
+    let
+        cities model =
+            model.country
+                |> Maybe.andThen (\c -> Dict.get c allCities)
+                |> Maybe.withDefault []
+    in
+    dropdownConfig cities .city CityDropdownMsg CityPicked
 
 
-dropdownConfig : (Model -> Maybe String) -> (Dropdown.Msg String -> Msg) -> (Maybe String -> Msg) -> Dropdown.Config String Msg Model
-dropdownConfig selectedFromModel dropdownMsg itemPickedMsg =
+dropdownConfig : (Model -> List String) -> (Model -> Maybe String) -> (Dropdown.Msg String -> Msg) -> (Maybe String -> Msg) -> Dropdown.Config String Msg Model
+dropdownConfig allOptions selectedFromModel dropdownMsg itemPickedMsg =
     let
         containerAttrs =
             [ width (px 300) ]
@@ -198,7 +193,7 @@ dropdownConfig selectedFromModel dropdownMsg itemPickedMsg =
                 ]
                 (text i)
     in
-    Dropdown.filterable selectedFromModel dropdownMsg itemPickedMsg itemToPrompt itemToElement identity
+    Dropdown.filterable allOptions selectedFromModel dropdownMsg itemPickedMsg itemToPrompt itemToElement identity
         |> Dropdown.withContainerAttributes containerAttrs
         |> Dropdown.withSelectAttributes selectAttrs
         |> Dropdown.withListAttributes listAttrs

--- a/examples/Example4.elm
+++ b/examples/Example4.elm
@@ -138,7 +138,15 @@ dropdownConfig =
                 , el [ Font.size 16 ] (text i)
                 ]
     in
-    Dropdown.filterable (always options) .selectedOption DropdownMsg OptionPicked itemToPrompt itemToElement identity
+    Dropdown.filterable
+        { allItems = always options
+        , selectedItem = .selectedOption
+        , dropdownMsg = DropdownMsg
+        , onSelectMsg = OptionPicked
+        , itemToPrompt = itemToPrompt
+        , itemToElement = itemToElement
+        , itemToText = identity
+        }
         |> Dropdown.withContainerAttributes containerAttrs
         |> Dropdown.withSelectAttributes selectAttrs
         |> Dropdown.withListAttributes listAttrs

--- a/examples/Example4.elm
+++ b/examples/Example4.elm
@@ -19,9 +19,13 @@ main =
         }
 
 
+type alias Item =
+    String
+
+
 type alias Model =
-    { dropdownState : Dropdown.State
-    , selectedOption : Maybe String
+    { dropdownState : Dropdown.State Item
+    , selectedOption : Maybe Item
     }
 
 
@@ -34,7 +38,7 @@ init _ =
     )
 
 
-options : List String
+options : List Item
 options =
     List.range 1 100
         |> List.map String.fromInt
@@ -46,8 +50,8 @@ options =
 
 
 type Msg
-    = OptionPicked (Maybe String)
-    | DropdownMsg (Dropdown.Msg String)
+    = OptionPicked (Maybe Item)
+    | DropdownMsg (Dropdown.Msg Item)
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -87,7 +91,7 @@ view model =
         |> layout []
 
 
-dropdownConfig : Dropdown.Config String Msg Model
+dropdownConfig : Dropdown.Config Item Msg Model
 dropdownConfig =
     let
         containerAttrs =

--- a/examples/Example4.elm
+++ b/examples/Example4.elm
@@ -59,7 +59,7 @@ update msg model =
         DropdownMsg subMsg ->
             let
                 ( state, cmd ) =
-                    Dropdown.update dropdownConfig subMsg model model.dropdownState options
+                    Dropdown.update dropdownConfig subMsg model model.dropdownState
             in
             ( { model | dropdownState = state }, cmd )
 
@@ -81,7 +81,7 @@ view : Model -> Html Msg
 view model =
     column [ padding 20, spacing 20 ]
         [ el [] <| text <| "Selected Option: " ++ (model.selectedOption |> Maybe.withDefault "Nothing")
-        , Dropdown.view dropdownConfig model model.dropdownState options
+        , Dropdown.view dropdownConfig model model.dropdownState
         , el [] <| text "other content"
         ]
         |> layout []
@@ -138,7 +138,7 @@ dropdownConfig =
                 , el [ Font.size 16 ] (text i)
                 ]
     in
-    Dropdown.filterable .selectedOption DropdownMsg OptionPicked itemToPrompt itemToElement identity
+    Dropdown.filterable (always options) .selectedOption DropdownMsg OptionPicked itemToPrompt itemToElement identity
         |> Dropdown.withContainerAttributes containerAttrs
         |> Dropdown.withSelectAttributes selectAttrs
         |> Dropdown.withListAttributes listAttrs

--- a/examples/Example5.elm
+++ b/examples/Example5.elm
@@ -59,7 +59,7 @@ update msg model =
         DropdownMsg subMsg ->
             let
                 ( state, cmd ) =
-                    Dropdown.update dropdownConfig subMsg model model.dropdownState options
+                    Dropdown.update dropdownConfig subMsg model model.dropdownState
             in
             ( { model | dropdownState = state }, cmd )
 
@@ -70,7 +70,7 @@ update msg model =
 
 view : Model -> Html Msg
 view model =
-    Dropdown.view dropdownConfig model model.dropdownState options
+    Dropdown.view dropdownConfig model model.dropdownState
         |> el []
         |> layout []
 
@@ -150,7 +150,7 @@ dropdownConfig =
                 , label = Input.labelRight [ paddingEach { edges | left = 7 } ] <| text item
                 }
     in
-    Dropdown.multi .selectedOptions DropdownMsg OptionsPicked itemsToPrompt itemToElement
+    Dropdown.multi (always options) .selectedOptions DropdownMsg OptionsPicked itemsToPrompt itemToElement
         |> Dropdown.withPromptElement btn
         |> Dropdown.withListAttributes listAttrs
         |> Dropdown.withSelectAttributes selectAttrs

--- a/examples/Example5.elm
+++ b/examples/Example5.elm
@@ -150,7 +150,14 @@ dropdownConfig =
                 , label = Input.labelRight [ paddingEach { edges | left = 7 } ] <| text item
                 }
     in
-    Dropdown.multi (always options) .selectedOptions DropdownMsg OptionsPicked itemsToPrompt itemToElement
+    Dropdown.multi
+        { allItems = always options
+        , selectedItems = .selectedOptions
+        , dropdownMsg = DropdownMsg
+        , onSelectMsg = OptionsPicked
+        , itemsToPrompt = itemsToPrompt
+        , itemToElement = itemToElement
+        }
         |> Dropdown.withPromptElement btn
         |> Dropdown.withListAttributes listAttrs
         |> Dropdown.withSelectAttributes selectAttrs

--- a/examples/Example5.elm
+++ b/examples/Example5.elm
@@ -20,9 +20,13 @@ subscriptions model =
     Dropdown.onOutsideClick model.dropdownState DropdownMsg
 
 
+type alias Item =
+    String
+
+
 type alias Model =
-    { dropdownState : Dropdown.State
-    , selectedOptions : List String
+    { dropdownState : Dropdown.State Item
+    , selectedOptions : List Item
     }
 
 
@@ -31,7 +35,7 @@ init _ =
     ( { dropdownState = Dropdown.init "my-dropdown", selectedOptions = options |> List.take 2 }, Cmd.none )
 
 
-options : List String
+options : List Item
 options =
     List.range 1 10 |> List.map (\item -> "Option " ++ String.fromInt item)
 
@@ -41,9 +45,9 @@ options =
 
 
 type Msg
-    = OptionsPicked (List String)
+    = OptionsPicked (List Item)
     | ChechboxChecked Bool
-    | DropdownMsg (Dropdown.Msg String)
+    | DropdownMsg (Dropdown.Msg Item)
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -106,7 +110,7 @@ btn =
         }
 
 
-dropdownConfig : Dropdown.Config String Msg Model
+dropdownConfig : Dropdown.Config Item Msg Model
 dropdownConfig =
     let
         arrow icon =

--- a/src/Dropdown.elm
+++ b/src/Dropdown.elm
@@ -140,25 +140,33 @@ init id =
 
 {-| Create a basic configuration. This takes:
 
-    - The list of items to display in the dropdown (as a function of the model)
-    - The function to get the selected item from the model
-    - The message to wrap all the internal messages of the dropdown
-    - A message to trigger when an item is selected
-    - A function to get the Element to display from an item, to be used in the select part of the dropdown
-    - A function to get the Element to display from an item, to be used in the item list of the dropdown
+    - allItems - The list of items to display in the dropdown (as a function of the model)
+    - selectedItem - The function to get the selected item from the model
+    - dropdownMsg - The message to wrap all the internal messages of the dropdown
+    - onSelectMsg - A message to trigger when an item is selected
+    - itemToPrompt - A function to get the Element to display from an item, to be used in the select part of the dropdown
+    - itemToElement - A function to get the Element to display from an item, to be used in the item list of the dropdown
 
-    Dropdown.basic DropdownMsg OptionPicked Element.text Element.text
+    Dropdown.basic
+        { allItems = always [ "apples", "bananas", "oranges" ]
+        , selectedItem = .selectedFruit
+        , dropdownMsg = DropdownMsg
+        , onSelectMsg = FruitPicked
+        , itemToPrompt = Element.text
+        , itemToElement = Element.text
+        }
 
 -}
 basic :
-    (model -> List item)
-    -> (model -> Maybe item)
-    -> (Msg item -> msg)
-    -> (Maybe item -> msg)
-    -> (item -> Element msg)
-    -> (Bool -> Bool -> item -> Element msg)
+    { allItems : model -> List item
+    , selectedItem : model -> Maybe item
+    , dropdownMsg : Msg item -> msg
+    , onSelectMsg : Maybe item -> msg
+    , itemToPrompt : item -> Element msg
+    , itemToElement : Bool -> Bool -> item -> Element msg
+    }
     -> Config item msg model
-basic allOptions selectionFromModel dropdownMsg onSelectMsg itemToPrompt itemToElement =
+basic { allItems, selectedItem, dropdownMsg, onSelectMsg, itemToPrompt, itemToElement } =
     Config
         { closeButton = text "▲"
         , containerAttributes = []
@@ -170,8 +178,8 @@ basic allOptions selectionFromModel dropdownMsg onSelectMsg itemToPrompt itemToE
         , itemToText = \_ -> ""
         , listAttributes = []
         , onSelectMsg = OnSelectSingleItem onSelectMsg
-        , allOptions = allOptions
-        , selectionFromModel = selectionFromModel >> SingleItem
+        , allOptions = allItems
+        , selectionFromModel = selectedItem >> SingleItem
         , openButton = text "▼"
         , promptElement = el [ width fill ] (text "-- Select --")
         , searchAttributes = []
@@ -181,25 +189,24 @@ basic allOptions selectionFromModel dropdownMsg onSelectMsg itemToPrompt itemToE
 
 {-| Create a multiselect configuration. This takes:
 
-    - The list of items to display in the dropdown (as a function of the model)
-    - The function to get the selected items from the model
-    - The message to wrap all the internal messages of the dropdown
-    - A message to trigger when an item is selected
-    - A function to get the Element to display from the list of selected items, to be used in the select part of the dropdown
-    - A function to get the Element to display from an item, to be used in the item list of the dropdown
-
-    Dropdown.multiselect DropdownMsg OptionsPicked Element.text Element.text
+    - allItems - The list of items to display in the dropdown (as a function of the model)
+    - selectedItems - The function to get the selected items from the model
+    - dropdownMsg - The message to wrap all the internal messages of the dropdown
+    - onSelectMsg - A message to trigger when an item is selected
+    - itemsToPrompt - A function to get the Element to display from the list of selected items, to be used in the select part of the dropdown
+    - itemToElement - A function to get the Element to display from an item, to be used in the item list of the dropdown
 
 -}
 multi :
-    (model -> List item)
-    -> (model -> List item)
-    -> (Msg item -> msg)
-    -> (List item -> msg)
-    -> (List item -> Element msg)
-    -> (Bool -> Bool -> item -> Element msg)
+    { allItems : model -> List item
+    , selectedItems : model -> List item
+    , dropdownMsg : Msg item -> msg
+    , onSelectMsg : List item -> msg
+    , itemsToPrompt : List item -> Element msg
+    , itemToElement : Bool -> Bool -> item -> Element msg
+    }
     -> Config item msg model
-multi allOptions selectionFromModel dropdownMsg onSelectMsg itemsToPrompt itemToElement =
+multi { allItems, selectedItems, dropdownMsg, onSelectMsg, itemsToPrompt, itemToElement } =
     Config
         { closeButton = text "▲"
         , containerAttributes = []
@@ -211,8 +218,8 @@ multi allOptions selectionFromModel dropdownMsg onSelectMsg itemsToPrompt itemTo
         , itemToText = \_ -> ""
         , listAttributes = []
         , onSelectMsg = OnSelectMultipleItems onSelectMsg
-        , allOptions = allOptions
-        , selectionFromModel = selectionFromModel >> MultipleItems
+        , allOptions = allItems
+        , selectionFromModel = selectedItems >> MultipleItems
         , openButton = text "▼"
         , promptElement = el [ width fill ] (text "-- Select --")
         , searchAttributes = []
@@ -222,27 +229,26 @@ multi allOptions selectionFromModel dropdownMsg onSelectMsg itemsToPrompt itemTo
 
 {-| Create a filterable configuration. This takes:
 
-    - The list of items to display in the dropdown (as a function of the model)
-    - The function to get the selected item from the model
-    - The message to wrap all the internal messages of the dropdown
-    - A message to trigger when an item is selected
-    - A function to get the Element to display from an item, to be used in the select part of the dropdown
-    - A function to get the Element to display from an item, to be used in the item list of the dropdown
-    - A function to get the text representation from an item, to be used when filtering elements in the list
-
-    Dropdown.basic DropdownMsg OptionPicked Element.text Element.text
+    - allItems - The list of items to display in the dropdown (as a function of the model)
+    - selectedItem - The function to get the selected item from the model
+    - dropdownMsg - The message to wrap all the internal messages of the dropdown
+    - onSelectMsg - A message to trigger when an item is selected
+    - itemToPrompt - A function to get the Element to display from an item, to be used in the select part of the dropdown
+    - itemToElement - A function to get the Element to display from an item, to be used in the item list of the dropdown
+    - itemToText - A function to get the text representation from an item, to be used when filtering elements in the list
 
 -}
 filterable :
-    (model -> List item)
-    -> (model -> Maybe item)
-    -> (Msg item -> msg)
-    -> (Maybe item -> msg)
-    -> (item -> Element msg)
-    -> (Bool -> Bool -> item -> Element msg)
-    -> (item -> String)
+    { allItems : model -> List item
+    , selectedItem : model -> Maybe item
+    , dropdownMsg : Msg item -> msg
+    , onSelectMsg : Maybe item -> msg
+    , itemToPrompt : item -> Element msg
+    , itemToElement : Bool -> Bool -> item -> Element msg
+    , itemToText : item -> String
+    }
     -> Config item msg model
-filterable allOptions selectionFromModel dropdownMsg onSelectMsg itemToPrompt itemToElement itemToText =
+filterable { allItems, selectedItem, dropdownMsg, onSelectMsg, itemToPrompt, itemToElement, itemToText } =
     Config
         { closeButton = text "▲"
         , containerAttributes = []
@@ -254,8 +260,8 @@ filterable allOptions selectionFromModel dropdownMsg onSelectMsg itemToPrompt it
         , itemToText = itemToText
         , listAttributes = []
         , onSelectMsg = OnSelectSingleItem onSelectMsg
-        , allOptions = allOptions
-        , selectionFromModel = selectionFromModel >> SingleItem
+        , allOptions = allItems
+        , selectionFromModel = selectedItem >> SingleItem
         , openButton = text "▼"
         , promptElement = el [ width fill ] (text "-- Select --")
         , searchAttributes = []

--- a/src/Dropdown.elm
+++ b/src/Dropdown.elm
@@ -67,7 +67,9 @@ type Selection item
         }
 
 -}
-type State
+type
+    State item
+    -- item type parameter is not currently used, but keeping it so if it does ever become needed it doesn't change the public api
     = State InternalState
 
 
@@ -135,7 +137,7 @@ type Key
     }
 
 -}
-init : String -> State
+init : String -> State item
 init id =
     State
         { id = id
@@ -355,7 +357,7 @@ withListAttributes attrs (Config config) =
             ( { model | dropdownState = updated }, cmd )
 
 -}
-update : Config item msg model -> Msg item -> model -> State -> ( State, Cmd msg )
+update : Config item msg model -> Msg item -> model -> State item -> ( State item, Cmd msg )
 update (Config config) msg model (State state) =
     let
         allOptions =
@@ -523,7 +525,7 @@ closeOnlyIfNotMultiSelect config state =
     Dropdown.view dropdownConfig model model.dropdownState model.items
 
 -}
-view : Config item msg model -> model -> State -> Element msg
+view : Config item msg model -> model -> State item -> Element msg
 view (Config config) model (State state) =
     let
         allOptions =
@@ -817,6 +819,6 @@ outsideTarget dropdownId dropdownMsg =
         Dropdown.onOutsideClick model.dropdownState DropdownMsg
 
 -}
-onOutsideClick : State -> (Msg item -> msg) -> Sub msg
+onOutsideClick : State item -> (Msg item -> msg) -> Sub msg
 onOutsideClick (State state) dropdownMsg =
     onMouseDown (outsideTarget state.id dropdownMsg)


### PR DESCRIPTION
This is the change to remove the parameter giving the list of options to display in the dropdown from the update and view functions and instead put it into the config (as a function of the model) to make the api more consistent with previous change, as discussed in https://github.com/PaackEng/elm-ui-dropdown/pull/24