### PR TITLE
Renaming  config record fields

### DIFF
--- a/examples/Example1.elm
+++ b/examples/Example1.elm
@@ -93,8 +93,8 @@ dropdownConfig =
             text item
     in
     Dropdown.basic
-        { allItems = always options
-        , selectedItem = .selectedOption
+        { itemsFromModel = always options
+        , selectionFromModel = .selectedOption
         , dropdownMsg = DropdownMsg
         , onSelectMsg = OptionPicked
         , itemToPrompt = itemToPrompt

--- a/examples/Example2.elm
+++ b/examples/Example2.elm
@@ -133,8 +133,8 @@ dropdownConfig =
                 ]
     in
     Dropdown.filterable
-        { allItems = always options
-        , selectedItem = .selectedOption
+        { itemsFromModel = always options
+        , selectionFromModel = .selectedOption
         , dropdownMsg = DropdownMsg
         , onSelectMsg = OptionPicked
         , itemToPrompt = itemToPrompt

--- a/examples/Example3.elm
+++ b/examples/Example3.elm
@@ -152,7 +152,7 @@ cityConfig =
 
 
 dropdownConfig : (Model -> List String) -> (Model -> Maybe String) -> (Dropdown.Msg String -> Msg) -> (Maybe String -> Msg) -> Dropdown.Config String Msg Model
-dropdownConfig allOptions selectedFromModel dropdownMsg itemPickedMsg =
+dropdownConfig items selectionFromModel dropdownMsg itemPickedMsg =
     let
         containerAttrs =
             [ width (px 300) ]
@@ -194,8 +194,8 @@ dropdownConfig allOptions selectedFromModel dropdownMsg itemPickedMsg =
                 (text i)
     in
     Dropdown.filterable
-        { allItems = allOptions
-        , selectedItem = selectedFromModel
+        { itemsFromModel = items
+        , selectionFromModel = selectionFromModel
         , dropdownMsg = dropdownMsg
         , onSelectMsg = itemPickedMsg
         , itemToPrompt = itemToPrompt

--- a/examples/Example4.elm
+++ b/examples/Example4.elm
@@ -143,8 +143,8 @@ dropdownConfig =
                 ]
     in
     Dropdown.filterable
-        { allItems = always options
-        , selectedItem = .selectedOption
+        { itemsFromModel = always options
+        , selectionFromModel = .selectedOption
         , dropdownMsg = DropdownMsg
         , onSelectMsg = OptionPicked
         , itemToPrompt = itemToPrompt

--- a/examples/Example5.elm
+++ b/examples/Example5.elm
@@ -155,8 +155,8 @@ dropdownConfig =
                 }
     in
     Dropdown.multi
-        { allItems = always options
-        , selectedItems = .selectedOptions
+        { itemsFromModel = always options
+        , selectionFromModel = .selectedOptions
         , dropdownMsg = DropdownMsg
         , onSelectMsg = OptionsPicked
         , itemsToPrompt = itemsToPrompt


### PR DESCRIPTION
First, I have to thank you again @rachel-barrett after all those improvements you have added to this package.

Before release the next version, I wanted to propose a change regarding some field names. As we have some fields `itemToPrompt` or `itemToElement` to mark fields that are functions, I wanted to make the new fields close to this approach. so that's why I'm renaming `allItems` and `selectedItem` to `itemsFromModel` and `selectionFromModel`. 

As I'm not sure if this makes sense or not, I want to hear your opinion about that (I want to hear from you @rachel-barrett  as well).