### PR TITLE
Remove duplicated options list when the dropdown it's opened

### DIFF
--- a/src/Dropdown.elm
+++ b/src/Dropdown.elm
@@ -556,8 +556,7 @@ view (Config config) model (State state) =
     in
     column
         containerAttrs
-        [ el [ width fill, below body ] trigger
-        ]
+        [ el [ width fill ] trigger ]
 
 
 triggerView : InternalConfig item msg model -> List item -> InternalState -> Element msg


### PR DESCRIPTION
For some reason, we were rendering the options list twice, there is no reason to render this twice, it was a bug there I think.

This solves #28 